### PR TITLE
v0.1.3 - Fix generic passwords collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@virgilsecurity/key-storage-rn",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "IKeyEntryStorage implementation for React Native",
   "files": [
     "dist",
@@ -23,8 +23,7 @@
   },
   "peerDependencies": {
     "expo": "^31.0.6",
-    "react-native-keychain": "^3.0.0",
-    "virgil-sdk": "^5.1.1"
+    "react-native-keychain": "^3.0.0"
   },
   "devDependencies": {
     "@types/expo": "^31.0.1",

--- a/src/ExpoStorage.ts
+++ b/src/ExpoStorage.ts
@@ -1,8 +1,9 @@
 import { SecureStore } from 'expo';
-import { IKeyEntry } from 'virgil-sdk';
 
 import IStorage from './IStorage';
 import { serializeKeyEntries, deserializeKeyEntries } from './KeyEntryUtils';
+
+type IKeyEntry = import('virgil-sdk').IKeyEntry;
 
 export interface ExpoStorageOptions extends SecureStore.SecureStoreOptions {
   key?: string;

--- a/src/IStorage.ts
+++ b/src/IStorage.ts
@@ -1,4 +1,4 @@
-import { IKeyEntry } from 'virgil-sdk';
+type IKeyEntry = import('virgil-sdk').IKeyEntry;
 
 export default interface IKeyEntryStorage {
   getKeyEntries(): Promise<Map<string, IKeyEntry>>;

--- a/src/KeyEntryStorage.ts
+++ b/src/KeyEntryStorage.ts
@@ -1,13 +1,10 @@
-import {
-  IKeyEntryStorage,
-  IKeyEntry,
-  ISaveKeyEntryParams,
-  IUpdateKeyEntryParams,
-  KeyEntryAlreadyExistsError,
-  KeyEntryDoesNotExistError,
-} from 'virgil-sdk';
-
 import IStorage from './IStorage';
+import { KeyEntryAlreadyExistsError, KeyEntryDoesNotExistError } from './errors';
+
+type IKeyEntryStorage = import('virgil-sdk').IKeyEntryStorage;
+type IKeyEntry = import('virgil-sdk').IKeyEntry;
+type ISaveKeyEntryParams = import('virgil-sdk').ISaveKeyEntryParams;
+type IUpdateKeyEntryParams = import('virgil-sdk').IUpdateKeyEntryParams;
 
 export default class KeyEntryStorage implements IKeyEntryStorage {
   private readonly storage: IStorage;

--- a/src/KeyEntryUtils.ts
+++ b/src/KeyEntryUtils.ts
@@ -1,4 +1,4 @@
-import { IKeyEntry } from 'virgil-sdk';
+type IKeyEntry = import('virgil-sdk').IKeyEntry;
 
 interface SerializedKeyEntry {
   name: string;

--- a/src/NativeStorage.ts
+++ b/src/NativeStorage.ts
@@ -4,26 +4,29 @@ import {
   getGenericPassword,
   resetGenericPassword,
 } from 'react-native-keychain';
-import { IKeyEntry } from 'virgil-sdk';
 
 import IStorage from './IStorage';
 import { serializeKeyEntries, deserializeKeyEntries } from './KeyEntryUtils';
+
+type IKeyEntry = import('virgil-sdk').IKeyEntry;
 
 export interface NativeStorageOptions extends Options {
   username?: string;
 }
 
 export default class NativeStorage implements IStorage {
-  private static readonly DEFAULT_USERNAME: string = '_VIRGIL_KEY_ENTRY_STORAGE';
+  private static readonly DEFAULT_KEYCHAIN_SERVICE_NAME: string = '_VIRGIL_KEY_ENTRY_STORAGE';
 
-  private readonly username: string = NativeStorage.DEFAULT_USERNAME;
+  private readonly keychainServiceName: string = NativeStorage.DEFAULT_KEYCHAIN_SERVICE_NAME;
   private readonly options?: Options;
 
   constructor(options?: NativeStorageOptions) {
-    if (typeof options !== 'undefined') {
-      const { username, ...keychainOptions } = options;
-      this.username = username || NativeStorage.DEFAULT_USERNAME;
-      this.options = keychainOptions;
+    if (options == null) {
+      this.options = {
+        service: this.keychainServiceName,
+      };
+    } else {
+      this.options = options;
     }
   }
 
@@ -37,7 +40,7 @@ export default class NativeStorage implements IStorage {
 
   async setKeyEntries(keyEntries: Map<string, IKeyEntry>): Promise<void> {
     const value = serializeKeyEntries(keyEntries);
-    await setGenericPassword(this.username, value, this.options);
+    await setGenericPassword(this.keychainServiceName, value, this.options);
   }
 
   async clear(): Promise<void> {

--- a/src/__tests__/KeyEntryStorage.test.ts
+++ b/src/__tests__/KeyEntryStorage.test.ts
@@ -1,7 +1,8 @@
-import { IKeyEntry, KeyEntryAlreadyExistsError, KeyEntryDoesNotExistError } from 'virgil-sdk';
+import { IKeyEntry } from 'virgil-sdk';
 
 import IStorage from '../IStorage';
 import KeyEntryStorage from '../KeyEntryStorage';
+import { KeyEntryAlreadyExistsError, KeyEntryDoesNotExistError } from '../errors';
 
 class Storage implements IStorage {
   private keyEntries: Map<string, IKeyEntry> = new Map();

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,26 @@
+export class VirgilKeyStorageRnError extends Error {
+  name: string;
+  constructor(m: string, name: string = 'VirgilError') {
+    super(m);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = name;
+  }
+}
+
+export class KeyEntryAlreadyExistsError extends VirgilKeyStorageRnError {
+  constructor(name?: string) {
+    super(
+      `Key entry ${name ? `named ${name}` : 'with same name'}already exists`,
+      'KeyEntryAlreadyExistsError',
+    );
+  }
+}
+
+export class KeyEntryDoesNotExistError extends VirgilKeyStorageRnError {
+  constructor(name: string) {
+    super(
+      `Key entry ${name ? `named ${name}` : 'with the given name'} does not exist.`,
+      'KeyEntryDoesNotExistError',
+    );
+  }
+}


### PR DESCRIPTION
- Remove virgil-sdk as peer dependency. RN Key Storage can be used with e3kit and without SDK.
- Dynamic import for typing resolves to type definition only.
- `react-native-keychain` is returns only one record, and doesn't care about username. By using service name we can create unique keychain instance. https://stackoverflow.com/questions/11614047/what-makes-a-keychain-item-unique-in-ios